### PR TITLE
Make interface more consistent in order to avoid incompatibilities with FactoryBot 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ RSpec.describe WidgetsController, type: :controller do
   let(:test_widget_params) {{ name: "Goat Herder" }}
 
   describe_restful_index_action
+  describe_restful_show_action(Widget)
   describe_restful_new_action
   describe_restful_create_action(Widget, url_method: :widgets_path)
-  describe_restful_edit_action(:widget)
+  describe_restful_edit_action(Widget)
   describe_restful_update_action(Widget, url_method: :widgets_path, object_method: :widget)
   describe_restful_destroy_action(Widget, url_method: :widgets_path)
 end


### PR DESCRIPTION
Version 0.1.1 of this gem generates the following:

> DEPRECATION WARNING: Looking up factories by class is deprecated and will be removed in 5.0. Use symbols instead and set FactoryBot.allow_class_lookup = false. (called from block (2 levels) in describe_restful_edit_action at /Users/michael/repos/rspec-restful/lib/rspec_restful/controller_helpers.rb:97)

Upon further investigation, I wondered why we need to allow for both class and symbol arguments so I have made it all consistent by requiring a class.