### PR TITLE
Replace success? with successful? for Rails 6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this gem will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1] - 2023-04-07
+### Changed
+- Replaced `be_success` with `be_successful` for Rails 6 compatibility

--- a/lib/rspec_restful/controller_helpers.rb
+++ b/lib/rspec_restful/controller_helpers.rb
@@ -7,7 +7,7 @@ module RspecRestful
         end
 
         it 'renders the :index template with 200 status' do
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(response).to render_template('index')
         end
       end
@@ -22,7 +22,7 @@ module RspecRestful
         end
 
         it 'renders the :show template with 200 status' do
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(response).to render_template('show')
         end
       end
@@ -35,7 +35,7 @@ module RspecRestful
         end
 
         it 'renders the :new template with 200 status' do
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(response).to render_template('new')
         end
       end
@@ -76,7 +76,7 @@ module RspecRestful
           end
 
           it 'renders the :new template with 200 status' do
-            expect(response).to be_success
+            expect(response).to be_successful
             expect(response).to render_template(:new)
           end
 
@@ -102,7 +102,7 @@ module RspecRestful
         end
 
         it 'renders the :edit template with 200 status' do
-          expect(response).to be_success
+          expect(response).to be_successful
           expect(response).to render_template('edit')
         end
       end
@@ -140,7 +140,7 @@ module RspecRestful
           end
 
           it 'renders the :edit template with 200 status' do
-            expect(response).to be_success
+            expect(response).to be_successful
             expect(response).to render_template('edit')
           end
         end

--- a/lib/rspec_restful/version.rb
+++ b/lib/rspec_restful/version.rb
@@ -1,3 +1,3 @@
 module RspecRestful
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/rspec_restful.gemspec
+++ b/rspec_restful.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Fixes deprecation warning:

> The success? predicate is deprecated and will be removed in Rails 6.0.
       Please use successful? as provided by Rack::Response::Helpers.
